### PR TITLE
Replace Unicode `í` with ASCII `i`

### DIFF
--- a/vignettes/GUIDEseq.Rnw
+++ b/vignettes/GUIDEseq.Rnw
@@ -117,7 +117,7 @@ Here is an example line. \linebreak
 chr13 27629253 27629403 HWI-M01326:156:1:113:4572:6938/1 44 + 150M \linebreak
 When fastq files are available, scripts for bin reads, remove adaptor, mapping to genome are available \linebreak
 at http://mccb.umassmed.edu/GUIDE-seq/. Otherwise, a one-line, 6-argument pipeline GS-Preprocess at 
-https://github.com/umasstr/GS-Preprocess (Rodríguez et al., 2021) can be used to generate the 
+https://github.com/umasstr/GS-Preprocess (Rodriguez et al., 2021) can be used to generate the 
 needed input files for GUIDEseq. The input file for GS-Preprocess is the standard raw data 
 output in BCL file format. 
 
@@ -267,7 +267,7 @@ and Michael Brodsky. CRISPRseek: a Bioconductor package to identify
 target-specific guide RNAs for CRISPR-Cas9 genome-editing systems. Plos One 
 Sept 23rd 2014
 \bibitem{Zhu et al., 2017}Lihua Julie Zhu, Michael Lawrence, Ankit Gupta, Herve Pages, Alper Kucukural, Manuel Garber and Scot A. Wolfe. GUIDEseq: a bioconductor package to analyze GUIDE-Seq datasets for CRISPR-Cas nucleases. BMC Genomics. 2017. 18:379
-\bibitem{Rodríguez et al., 2021}Rodríguez TC, Dadafarin S, Pratt HE, Liu P, Amrani N, Zhu LJ. Genome-wide detection and analysis of CRISPR-Cas off-targets. Reprogramming the Genome: CRISPR-Cas-based Human Disease Therapy, Volume 181 2021
+\bibitem{Rodriguez et al., 2021}Rodriguez TC, Dadafarin S, Pratt HE, Liu P, Amrani N, Zhu LJ. Genome-wide detection and analysis of CRISPR-Cas off-targets. Reprogramming the Genome: CRISPR-Cas-based Human Disease Therapy, Volume 181 2021
 \end{thebibliography}
 
 \section{Session Info}


### PR DESCRIPTION
The Unicode `í` is breaking LaTeX processing.

Apologies in advance if this is not a good fix for the problem but I don't have much experience with LaTeX and I was not able to find another one.

The Unicode `í` causes this [error](https://bioconductor.org/checkResults/3.18/bioc-LATEST/GUIDEseq/kunpeng2-buildsrc.html) while `R CMD build`ing this Bioc package on the new Linux aarch64 builder:

```
Error: processing vignette 'GUIDEseq.Rnw' failed with diagnostics:
Running 'texi2dvi' on 'GUIDEseq.tex' failed.
LaTeX errors:
! Missing \endcsname inserted.
<to be read again> 
                   \IeC 
l.631 \bibitem{Rodríguez et al., 2021}
                                       Rodríguez TC, Dadafarin S, Pratt HE,...
! Emergency stop.
<to be read again> 
                   \IeC 
l.631 \bibitem{Rodríguez et al., 2021}
                                       Rodríguez TC, Dadafarin S, Pratt HE,...
!  ==> Fatal error occurred, no output PDF file produced!
--- failed re-building ‘GUIDEseq.Rnw’
```

If you know of a better solution I'd be happy to test it !